### PR TITLE
Refactor file handling and dialog services

### DIFF
--- a/InkMD_Editor/Controls/MainMenu.xaml
+++ b/InkMD_Editor/Controls/MainMenu.xaml
@@ -23,29 +23,29 @@
                 <MenuFlyoutItem Text="New file" />
                 <MenuFlyoutSeparator />
                 <!--  open section  -->
-                <MenuFlyoutItem Command="{x:Bind StoragePickerViewModel.OpenFileCommand}" Text="Open file">
+                <MenuFlyoutItem Command="{x:Bind OpenFileCommand}" Text="Open file">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="O" Modifiers="Control" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Command="{x:Bind StoragePickerViewModel.OpenFolderCommand}" Text="Open folder">
+                <MenuFlyoutItem Command="{x:Bind OpenFolderCommand}" Text="Open folder">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="O" Modifiers="Control,Shift" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator />
-                <MenuFlyoutItem Command="{x:Bind StoragePickerViewModel.SaveCommand}" Text="Save">
+                <MenuFlyoutItem Command="{x:Bind SaveCommand}" Text="Save">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="S" Modifiers="Control" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutItem Command="{x:Bind StoragePickerViewModel.SaveAsFileCommand}" Text="Save As">
+                <MenuFlyoutItem Command="{x:Bind SaveAsFileCommand}" Text="Save As">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="S" Modifiers="Control,Shift" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator />
-                <MenuFlyoutItem Command="{x:Bind StoragePickerViewModel.ExitApplicationCommand}" Text="Exit" />
+                <MenuFlyoutItem Command="{x:Bind ExitApplicationCommand}" Text="Exit" />
             </MenuBarItem>
 
             <MenuBarItem Title="Edit">

--- a/InkMD_Editor/Controls/MainMenu.xaml.cs
+++ b/InkMD_Editor/Controls/MainMenu.xaml.cs
@@ -1,16 +1,62 @@
-using InkMD_Editor.ViewModels;
-using Microsoft.UI.Xaml.Controls;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using InkMD_Editor.Messagers;
+using InkMD_Editor.Services;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Threading.Tasks;
 
 namespace InkMD_Editor.Controls;
 
 public sealed partial class MainMenu : UserControl
 {
-    public StoragePickerViewModel? StoragePickerViewModel { get; } = new();
-    
+    private readonly FileService _fileService = new();
+
     public MainMenu ()
     {
         InitializeComponent();
+    }
+
+    [RelayCommand]
+    private async Task OpenFile ()
+    {
+        var storageFile = await _fileService.OpenFileAsync();
+        if ( storageFile is not null )
+        {
+            WeakReferenceMessenger.Default.Send(new FileOpenedMessage(storageFile));
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenFolder ()
+    {
+        var storageFolder = await _fileService.OpenFolderAsync();
+        if ( storageFolder is not null )
+        {
+            WeakReferenceMessenger.Default.Send(new FolderOpenedMessage(storageFolder));
+        }
+    }
+
+    [RelayCommand]
+    private void Save ()
+    {
+        WeakReferenceMessenger.Default.Send(new SaveFileMessage(isNewFile: false));
+    }
+
+    [RelayCommand]
+    private async Task SaveAsFile ()
+    {
+        var filePath = await _fileService.SaveFileAsync();
+        if ( filePath is not null )
+        {
+            WeakReferenceMessenger.Default.Send(new SaveFileRequestMessage(filePath));
+        }
+    }
+
+    [RelayCommand]
+    private static void ExitApplication ()
+    {
+        App.Current.Exit();
     }
 
     public void SetVisibility (bool isVisible)

--- a/InkMD_Editor/Interfaces/IFileService.cs
+++ b/InkMD_Editor/Interfaces/IFileService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace InkMD_Editor.Interfaces;
+
+public interface IFileService
+{
+    Task<StorageFolder?> OpenFolderAsync ();
+    Task<StorageFile?> OpenFileAsync ();
+    Task<string?> SaveFileAsync ();
+}

--- a/InkMD_Editor/MainWindow.xaml.cs
+++ b/InkMD_Editor/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 
 namespace InkMD_Editor;
+
 public sealed partial class MainWindow : Window
 {
     public MainWindow ()

--- a/InkMD_Editor/Services/DialogService.cs
+++ b/InkMD_Editor/Services/DialogService.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Threading.Tasks;
+
+namespace InkMD_Editor.Services;
+
+public class DialogService
+{
+    private XamlRoot? _xamlRoot;
+
+    public void SetXamlRoot (XamlRoot xamlRoot) => _xamlRoot = xamlRoot;
+
+    public async Task ShowErrorAsync (string message)
+    {
+        if ( _xamlRoot is null )
+            return;
+        var dialog = new ContentDialog
+        {
+            Title = "Error" ,
+            Content = message ,
+            CloseButtonText = "OK" ,
+            XamlRoot = _xamlRoot
+        };
+        await dialog.ShowAsync();
+    }
+
+    public async Task ShowSuccessAsync (string message)
+    {
+        if ( _xamlRoot is null )
+            return;
+        var dialog = new ContentDialog
+        {
+            Title = "Done" ,
+            Content = message ,
+            CloseButtonText = "OK" ,
+            XamlRoot = _xamlRoot
+        };
+        await dialog.ShowAsync();
+    }
+}

--- a/InkMD_Editor/ViewModels/EditorViewModel.cs
+++ b/InkMD_Editor/ViewModels/EditorViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace InkMD_Editor.ViewModels;
+
+internal class EditorViewModel
+{
+}

--- a/InkMD_Editor/ViewModels/SettingViewModel.cs
+++ b/InkMD_Editor/ViewModels/SettingViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace InkMD_Editor.ViewModels;
+
+internal class SettingViewModel
+{
+}

--- a/InkMD_Editor/ViewModels/TabViewContentViewModel.cs
+++ b/InkMD_Editor/ViewModels/TabViewContentViewModel.cs
@@ -13,7 +13,7 @@ public partial class TabViewContentViewModel : ObservableObject
     public partial string? FileName { get; set; }
 
     [ObservableProperty]
-    public partial string? FilePath { get; set; } 
+    public partial string? FilePath { get; set; }
 
     /// <summary>
     /// Kiểm tra xem file đã được lưu chưa


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Refactored file handling from `StoragePickerViewModel` to a dedicated `FileService` and introduced a new `DialogService` for error/success dialogs. The changes improve separation of concerns by extracting file operations into a proper service layer.

Key changes:
- Moved `StoragePickerViewModel` → `FileService` with `IFileService` interface
- Created `DialogService` for centralized dialog management
- Updated `MainMenu` to use local `RelayCommand` methods instead of ViewModel binding
- Replaced direct messenger sending with service return values in file operations

Issues found:
- **Critical**: `XamlRoot` initialization timing issue in `EditorPage.xaml.cs:40` - `this.XamlRoot` is null during constructor, causing `DialogService` to silently fail when called from `InitTreeView`
- Inconsistent error handling mixing old `ShowErrorDialog` with new `_dialogService.ShowErrorAsync` pattern
- Empty placeholder ViewModels (`EditorViewModel`, `SettingViewModel`) added with no implementation

<h3>Confidence Score: 3/5</h3>


- This PR has a critical initialization bug that will cause silent dialog failures
- Score reflects a blocking issue where `XamlRoot` is set before it's available, causing the `DialogService` to silently fail in several code paths (lines 98, 119, 131, etc.). The refactoring itself is sound, but this timing bug will prevent error dialogs from displaying to users during page initialization.
- Pay close attention to `InkMD_Editor/Views/EditorPage.xaml.cs` - the `XamlRoot` initialization must be fixed before merging

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| InkMD_Editor/Services/FileService.cs | 5/5 | Refactored from `StoragePickerViewModel` to a proper service, separated file operations from messaging logic |
| InkMD_Editor/Services/DialogService.cs | 4/5 | New service for displaying dialogs, but silently fails when `XamlRoot` is null |
| InkMD_Editor/Controls/MainMenu.xaml.cs | 5/5 | Commands moved from ViewModel binding to direct RelayCommand implementations with FileService |
| InkMD_Editor/Views/EditorPage.xaml.cs | 3/5 | Integrated FileService and DialogService, but inconsistent error handling between old and new patterns |
| InkMD_Editor/Interfaces/IFileService.cs | 5/5 | New interface for file operations, clean abstraction |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->