### PR TITLE
minor fix

### DIFF
--- a/InkMD_Editor/Controls/MainMenu.xaml
+++ b/InkMD_Editor/Controls/MainMenu.xaml
@@ -297,7 +297,7 @@
                             FontSize="13"
                             Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                             IsTextSelectionEnabled="True"
-                            Text="Select at least 1 icon"
+                            Text="Choose an icon to see code"
                             TextWrapping="Wrap" />
                     </ScrollViewer>
                     <Button

--- a/InkMD_Editor/Controls/MainMenu.xaml.cs
+++ b/InkMD_Editor/Controls/MainMenu.xaml.cs
@@ -64,7 +64,7 @@ public sealed partial class MainMenu : UserControl
         }
         catch ( Exception ex )
         {
-            await _dialogService.ShowErrorAsync($"Can not load template: {ex.Message}");
+            await _dialogService.ShowErrorAsync($"Cannot load template: {ex.Message}");
         }
     }
 
@@ -81,7 +81,7 @@ public sealed partial class MainMenu : UserControl
             }
             catch ( Exception ex )
             {
-                await _dialogService.ShowErrorAsync($"Can not load template: {ex.Message}");
+                await _dialogService.ShowErrorAsync($"Cannot load template: {ex.Message}");
             }
         }
     }
@@ -125,7 +125,7 @@ public sealed partial class MainMenu : UserControl
         }
         catch ( Exception ex )
         {
-            await _dialogService.ShowErrorAsync($"Can not load icon: {ex.Message}");
+            await _dialogService.ShowErrorAsync($"Cannot load icon: {ex.Message}");
         }
     }
 
@@ -180,7 +180,7 @@ public sealed partial class MainMenu : UserControl
     {
         if ( TemplateDialog is null || previewWebView is null )
         {
-            await _dialogService.ShowErrorAsync("Error : Can not find dialog or viewer");
+            await _dialogService.ShowErrorAsync("Error : Cannot load dialog");
             return;
         }
 
@@ -200,7 +200,7 @@ public sealed partial class MainMenu : UserControl
         }
         catch ( Exception ex )
         {
-            await _dialogService.ShowErrorAsync($"Can not show preview: {ex.Message}");
+            await _dialogService.ShowErrorAsync($"Cannot show preview: {ex.Message}");
             return;
         }
 

--- a/InkMD_Editor/Controls/TabViewContent.xaml.cs
+++ b/InkMD_Editor/Controls/TabViewContent.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Diagnostics;
 
 namespace InkMD_Editor.Controls;
 
@@ -59,9 +58,8 @@ public sealed partial class TabViewContent : UserControl
             doc.GetText(TextGetOptions.None , out string text);
             return text ?? string.Empty;
         }
-        catch ( Exception ex )
+        catch ( Exception )
         {
-            Debug.WriteLine($"GetContent error: {ex.Message}");
             return string.Empty;
         }
     }

--- a/InkMD_Editor/Interfaces/IFileService.cs
+++ b/InkMD_Editor/Interfaces/IFileService.cs
@@ -8,5 +8,6 @@ public interface IFileService
     Task<StorageFolder?> OpenFolderAsync ();
     Task<StorageFile?> OpenFileAsync ();
     Task<string?> SaveFileAsync ();
-    Task<StorageFile?> CreateNewFileAsync (string suggestedName , string extension);
+    Task<StorageFile?> CreateNewFileAsync (string suggestedName , string? extension);
+    Task<StorageFile?> CreateFileDirectlyAsync (string fileName , string extension);
 }

--- a/InkMD_Editor/Services/FileService.cs
+++ b/InkMD_Editor/Services/FileService.cs
@@ -82,7 +82,7 @@ public class FileService : IFileService
             }
             catch ( Exception ex )
             {
-                WeakReferenceMessenger.Default.Send(new ErrorMessage($"Can not open folder: {ex.Message}"));
+                WeakReferenceMessenger.Default.Send(new ErrorMessage($"Cannot open folder: {ex.Message}"));
                 return null;
             }
         }
@@ -101,7 +101,7 @@ public class FileService : IFileService
         };
         picker.FileTypeChoices.Add("Markdown" , [".md"]);
         picker.FileTypeChoices.Add("Text" , [".txt"]);
-        picker.FileTypeChoices.Add("All Files" , ["."]);
+        picker.FileTypeChoices.Add("All Files" , ["*"]);
 
         var result = await picker.PickSaveFileAsync();
         if ( result is not null )
@@ -113,7 +113,7 @@ public class FileService : IFileService
             }
             catch ( Exception ex )
             {
-                WeakReferenceMessenger.Default.Send(new ErrorMessage($"Can not save file: {ex.Message}"));
+                WeakReferenceMessenger.Default.Send(new ErrorMessage($"Cannot save file: {ex.Message}"));
                 return null;
             }
         }
@@ -165,7 +165,7 @@ public class FileService : IFileService
         }
         catch ( Exception ex )
         {
-            WeakReferenceMessenger.Default.Send(new ErrorMessage($"Can not create file: {ex.Message}"));
+            WeakReferenceMessenger.Default.Send(new ErrorMessage($"Cannot create file: {ex.Message}"));
             return null;
         }
     }
@@ -194,7 +194,7 @@ public class FileService : IFileService
             picker.DefaultFileExtension = string.Empty;
         }
 
-        picker.FileTypeChoices.Add("All Files" , new List<string> { "." });
+        picker.FileTypeChoices.Add("All Files" , new List<string> { "*" });
 
         var result = await picker.PickSaveFileAsync();
         if ( result is not null )

--- a/InkMD_Editor/ViewModels/EditorPageViewModel.cs
+++ b/InkMD_Editor/ViewModels/EditorPageViewModel.cs
@@ -18,7 +18,7 @@ public partial class EditorPageViewModel : ObservableObject
     private DialogService _dialogService = new();
 
     [ObservableProperty]
-    public partial string RootPath { get; set; }
+    public partial string? RootPath { get; set; }
 
     public EditorPageViewModel ()
     {
@@ -46,7 +46,7 @@ public partial class EditorPageViewModel : ObservableObject
     {
         if ( content is null )
         {
-            await ShowErrorAsync("Can not get tab content");
+            await ShowErrorAsync("Cannot get tab content");
             return;
         }
 

--- a/InkMD_Editor/Views/EditorPage.xaml.cs
+++ b/InkMD_Editor/Views/EditorPage.xaml.cs
@@ -93,7 +93,7 @@ public sealed partial class EditorPage : Page
 
         if ( tabContent is null )
         {
-            await _viewModel.ShowErrorAsync("Can not access current documents.");
+            await _viewModel.ShowErrorAsync("Cannot access current documents.");
             return;
         }
 
@@ -168,7 +168,7 @@ public sealed partial class EditorPage : Page
         }
         catch ( Exception ex )
         {
-            await _viewModel.ShowErrorAsync($"Can not save file: {ex.Message}");
+            await _viewModel.ShowErrorAsync($"Cannot save file: {ex.Message}");
         }
     }
 
@@ -188,7 +188,7 @@ public sealed partial class EditorPage : Page
         }
         catch ( Exception ex )
         {
-            await _viewModel.ShowErrorAsync($"Can not open file: {ex.Message}");
+            await _viewModel.ShowErrorAsync($"Cannot open file: {ex.Message}");
         }
     }
 
@@ -223,7 +223,7 @@ public sealed partial class EditorPage : Page
         }
         catch ( Exception ex )
         {
-            await _viewModel.ShowErrorAsync($"Can not load items: {ex.Message}");
+            await _viewModel.ShowErrorAsync($"Cannot load items: {ex.Message}");
         }
     }
 
@@ -280,7 +280,7 @@ public sealed partial class EditorPage : Page
         }
         catch ( Exception ex )
         {
-            await _viewModel.ShowErrorAsync($"Can not open file: {ex.Message}");
+            await _viewModel.ShowErrorAsync($"Cannot open file: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix grammatical errors in error messages ("Can not" → "Cannot")

- Remove unused `System.Diagnostics` import and debug statement

- Update file picker filter from "." to "*" for all files

- Improve UI text clarity in icon selector

- Add nullable type annotation and new method to IFileService interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Error Messages"] -->|"Grammar fixes"| B["Cannot instead of Can not"]
  C["Code Cleanup"] -->|"Remove unused imports"| D["Delete Debug.WriteLine"]
  E["File Picker"] -->|"Fix filter pattern"| F["Use * instead of ."]
  G["UI Text"] -->|"Improve clarity"| H["Better icon selector message"]
  I["Interface Updates"] -->|"Add method & nullable"| J["CreateFileDirectlyAsync & nullable extension"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainMenu.xaml.cs</strong><dd><code>Fix grammatical errors in error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/Controls/MainMenu.xaml.cs

<ul><li>Replace "Can not" with "Cannot" in four error messages for grammatical <br>correctness<br> <li> Update error message in <code>ShowTemplatePreviewDialog</code> from "Can not find <br>dialog or viewer" to "Cannot load dialog"</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-e85b54ac9b36426971c81aa0381e883fc2ce644ebae5371363b8c310c6f77a51">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FileService.cs</strong><dd><code>Fix grammar and file picker filter patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/Services/FileService.cs

<ul><li>Replace "Can not" with "Cannot" in three error messages<br> <li> Fix file picker filter pattern from "." to "*" in two locations for <br>proper all-files filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-08af91405e579e6d246b22ef03aca5d4f135a3c34abaf4efb221d5d22284fd15">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EditorPageViewModel.cs</strong><dd><code>Add nullable type and fix grammar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/ViewModels/EditorPageViewModel.cs

<ul><li>Change <code>RootPath</code> property type from <code>string</code> to nullable <code>string?</code><br> <li> Replace "Can not" with "Cannot" in error message</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-ca29f5c1141c2f1bae8220e162ff13c8c801f86c0cc8465dd8dac54393b257bb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EditorPage.xaml.cs</strong><dd><code>Fix grammatical errors in error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/Views/EditorPage.xaml.cs

<ul><li>Replace "Can not" with "Cannot" in five error messages across <br>different methods<br> <li> Improve consistency of error messaging throughout the file</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-e667eba4f031533d3a5a85b38410599ab58446926bd0790c0f01e3a2ad2ede6f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TabViewContent.xaml.cs</strong><dd><code>Remove unused imports and debug statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/Controls/TabViewContent.xaml.cs

<ul><li>Remove unused <code>System.Diagnostics</code> import<br> <li> Remove exception parameter from catch block and delete <code>Debug.WriteLine</code> <br>statement<br> <li> Simplify error handling to return empty string without logging</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-8a6d9ff21fe25450488d94c63a5eb8fb8ca396ba34ed0d94beb96aefb745cb1e">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IFileService.cs</strong><dd><code>Add nullable parameter and new interface method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/Interfaces/IFileService.cs

<ul><li>Change <code>extension</code> parameter to nullable <code>string?</code> in <code>CreateNewFileAsync</code> <br>method<br> <li> Add new method <code>CreateFileDirectlyAsync</code> with <code>fileName</code> and <code>extension</code> <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-4b2f763b72d92b39fd5ab0be0accc69a2f8596ded32a30d7412b0ef0e4be546e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainMenu.xaml</strong><dd><code>Improve icon selector UI text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

InkMD_Editor/Controls/MainMenu.xaml

<ul><li>Update TextBlock text from "Select at least 1 icon" to "Choose an icon <br>to see code"<br> <li> Improve user interface clarity for icon selection feature</ul>


</details>


  </td>
  <td><a href="https://github.com/tribeti/InkMD-Editor/pull/17/files#diff-f1a50013ff0b10ef17555046682c8430aa2d7c1369ed39e8eb42d75fdbe3ffe4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

